### PR TITLE
[Search results]:SGA-173 Archive label Display

### DIFF
--- a/_includes/code/components/search-result-code.html
+++ b/_includes/code/components/search-result-code.html
@@ -1,11 +1,12 @@
 {% capture code_preview %}
-<h6>Without metadata</h6>
+<h6>Without Metadata</h6>
 <div class="usa-grid usa-search-result">
   <div class="usa-width-one-whole">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut ligula pulvinar elit.</p>
   </div>
 </div>
-<h6>With metadata</h6>
+
+<h6>With Metadata</h6>
 <div class="usa-grid usa-search-result">
   <div class="usa-width-two-thirds">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut ligula pulvinar elit.</p>
@@ -37,10 +38,11 @@
   </div>
 </div>
 
-<h6>Assistance Listings</h6>
 <div class="usa-grid usa-search-result">
-  <span class="usa-label">Federal Assistance Listing</span>
-  <span class="usa-label">ARCHIVED</span>
+  <p>
+    <span class="usa-label">Federal Assistance Listing</span>
+    <span class="usa-label">ARCHIVED</span>
+  </p>
   <h3>
     <a href="#">Fresh Fruit and Vegetable Program</a>
   </h3>
@@ -74,9 +76,10 @@
   </div>
 </div>
 
-<h6>Opportunities</h6>
 <div class="usa-grid usa-search-result">
-  <span class="usa-label">OPPORTUNITY</span>
+  <p>
+    <span class="usa-label">OPPORTUNITY</span>
+  </p>
   <h3>
     <a href="#">LAMP INCANDESCENT</a>
   </h3>

--- a/_includes/code/components/search-result-code.html
+++ b/_includes/code/components/search-result-code.html
@@ -1,26 +1,4 @@
 {% capture code_preview %}
-<h6>With metadata and action</h6>
-<div class="usa-grid usa-search-result">
-  <div class="usa-width-two-thirds">
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut ligula pulvinar elit.</p>
-  </div>
-  <div class="usa-width-one-third">
-    <p><span class="usa-label">New</span></p>
-    <p><strong>Metadata 1:</strong> This is a piece of metadata.</p>
-    <div class="usa-width-one-whole">
-      <div class="usa-action-container">
-        <span><a href="#"><i class="fa fa-archive"></i>Archive</a></span>
-      </div>
-      <div class="usa-action-container">
-        <span><a href="#"><i class="fa fa-pencil-square"></i>Edit</a></span>
-      </div>
-      <div class="usa-action-container delete">
-        <span><a href="#"><i class="fa fa-trash"></i>Delete</a></span>
-      </div>
-    </div>
-  </div>
-</div>
-
 <div class="usa-grid usa-search-result">
   <p>
     <span class="usa-label">Federal Assistance Listing</span>

--- a/_includes/code/components/search-result-code.html
+++ b/_includes/code/components/search-result-code.html
@@ -40,6 +40,7 @@
 <h6>Assistance Listings</h6>
 <div class="usa-grid usa-search-result">
   <span class="usa-label">Federal Assistance Listing</span>
+  <span class="usa-label">ARCHIVED</span>
   <h3>
     <a href="#">Fresh Fruit and Vegetable Program</a>
   </h3>
@@ -53,8 +54,7 @@
     </ul>
   </div>
   <div class="usa-width-one-third">
-    <p><span class="usa-label">ARCHIVED</span></p>
-    <ul class="usa-unstyled-list usa-text-small">
+    <ul class="usa-text-small">
       <li><strong>FAL Number</strong>
         <ul class="usa-unstyled-list">
           <li>10.582</li>
@@ -89,7 +89,7 @@
     </ul>
   </div>
   <div class="usa-width-one-third">
-    <ul class="usa-unstyled-list usa-text-small">
+    <ul class="usa-text-small">
       <li>
         <strong>Solicitation Number</strong>
         <ul class="usa-unstyled-list">

--- a/_includes/code/components/search-result-code.html
+++ b/_includes/code/components/search-result-code.html
@@ -53,7 +53,8 @@
     </ul>
   </div>
   <div class="usa-width-one-third">
-    <ul class="usa-text-small">
+    <p><span class="usa-label">ARCHIVED</span></p>
+    <ul class="usa-unstyled-list usa-text-small">
       <li><strong>FAL Number</strong>
         <ul class="usa-unstyled-list">
           <li>10.582</li>
@@ -88,7 +89,7 @@
     </ul>
   </div>
   <div class="usa-width-one-third">
-    <ul class="usa-text-small">
+    <ul class="usa-unstyled-list usa-text-small">
       <li>
         <strong>Solicitation Number</strong>
         <ul class="usa-unstyled-list">

--- a/_includes/code/components/search-result-code.html
+++ b/_includes/code/components/search-result-code.html
@@ -1,21 +1,4 @@
 {% capture code_preview %}
-<h6>Without Metadata</h6>
-<div class="usa-grid usa-search-result">
-  <div class="usa-width-one-whole">
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut ligula pulvinar elit.</p>
-  </div>
-</div>
-
-<h6>With Metadata</h6>
-<div class="usa-grid usa-search-result">
-  <div class="usa-width-two-thirds">
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut ligula pulvinar elit.</p>
-  </div>
-  <div class="usa-width-one-third">
-    <p><strong>Metadata 1:</strong> This is a piece of metadata.</p>
-  </div>
-</div>
-
 <h6>With metadata and action</h6>
 <div class="usa-grid usa-search-result">
   <div class="usa-width-two-thirds">

--- a/src/stylesheets/components/_search-result.scss
+++ b/src/stylesheets/components/_search-result.scss
@@ -2,3 +2,7 @@
   border-bottom: 1px solid $color-black;
   padding-bottom: 1em;
 }
+
+.usa-label {
+  margin-right: 1rem;
+}

--- a/src/stylesheets/components/_search-result.scss
+++ b/src/stylesheets/components/_search-result.scss
@@ -1,8 +1,9 @@
-.usa-grid.usa-search-result {
+.usa-search-result {
   border-bottom: 1px solid $color-black;
   padding-bottom: 1em;
+
+  .usa-label {
+    margin-right: 1rem;
+  }
 }
 
-.usa-label {
-  margin-right: 1rem;
-}


### PR DESCRIPTION
<!-- 
Please feel free to remove whatever sections or lines in this that aren't relevant.

Use the title line as the title of your pull request, then delete these lines. 

## Title line template: [Website or UI component]: [Brief description]

Website: Issues that impact SAM Web Design Standards look, feel, or functionality.
UI component: Issues that impact the look, feel, or functionality of the Standards themselves.

-->

## Initial suggestion for displaying archive label

* @joshbruce @kapilgrover After disussing with Kapil, I came up with two possibilities of displaying the "ARCHIVED" label for search result component. 

![screen shot 2016-09-23 at 11 17 13 am](https://cloud.githubusercontent.com/assets/18703498/18791706/d41160c4-8181-11e6-8298-1750c79fc9b4.png)

![screen shot 2016-09-23 at 11 19 55 am](https://cloud.githubusercontent.com/assets/18703498/18791715/d89eaebc-8181-11e6-87e1-dc18dbb93519.png)

* This pull request reflects results from the first image. Which one should we go with. Any other thoughts?